### PR TITLE
Making the dd command easier to read.

### DIFF
--- a/mkeosimg
+++ b/mkeosimg
@@ -68,7 +68,7 @@ fi
 
 echo "Creating $IMG with a size of $DRIVESIZE GB"
 let "SIZE = $DRIVESIZE * 1024"
-dd if=/dev/zero of=$IMG bs=1 count=0 seek=${SIZE}M
+dd if=/dev/zero of=$IMG bs=1M count=0 seek=$SIZE
 losetup $DEVICE $IMG
 parted --script $DEVICE mktable msdos
 parted --script $DEVICE mkpart primary fat32 1 150MB


### PR DESCRIPTION
I'd like to update the suggestion I made in issue #4.  Seek is a very strange place to have a unit in dd, i'd like to move it to block size where it should have been.

This has been tested, and produces a usable image of the expected size.  The resulting image was used to boot an erlite.

