### PR TITLE
Fix shellcheck warnings

### DIFF
--- a/mkeosdrive
+++ b/mkeosdrive
@@ -32,13 +32,13 @@ mkdir -p $BOOT_MNT
 mkdir -p $ROOT_MNT
 
 # Unmount all partitions on device
-umount ${DEVICE}? && echo "Unmounted all partitions on $DEVICE" || echo "no filesystem mounted from $DEVICE"
+umount "${DEVICE}"? && echo "Unmounted all partitions on $DEVICE" || echo "no filesystem mounted from $DEVICE"
 
 # Unmount folders only if already mounted
 grep -qs "$BOOT_MNT" /proc/mounts && umount $BOOT_MNT
 grep -qs "$ROOT_MNT" /proc/mounts && umount $ROOT_MNT
 
-DIR=`mktemp -d`
+DIR=$(mktemp -d)
 
 function cleanup {
     if [ -d "$DIR" ]
@@ -60,66 +60,66 @@ echo "Press any key to continue formatting $DEVICE"
 read -n1 -rsp $'or hit Ctrl+C to exit now...\n'
 
 # deleting existing partiton table first
-dd if=/dev/zero of=$DEVICE bs=512 count=1 conv=notrunc
+dd if=/dev/zero of="$DEVICE" bs=512 count=1 conv=notrunc
 
 echo "Waiting for disk sync..."
 sync
 
-parted --script $DEVICE mktable msdos
-parted --script $DEVICE mkpart primary fat32 1 150MB
+parted --script "$DEVICE" mktable msdos
+parted --script "$DEVICE" mkpart primary fat32 1 150MB
 
 # If no drive size was supplied as a parameter, default to full size root partition
-if [ ! -z $DRIVESIZE ]
+if [ -n "$DRIVESIZE" ]
 then
     echo "Creating root partition with an end cap size of $DRIVESIZE GB"
-    let "SIZE = $DRIVESIZE * 1024"
-    parted --script $DEVICE mkpart primary ext3 150MB ${SIZE}MB
+    (( SIZE = $DRIVESIZE * 1024 ))
+    parted --script "$DEVICE" mkpart primary ext3 150MB "${SIZE}"MB
 else
-    parted --script $DEVICE mkpart primary ext3 150MB 100%
+    parted --script "$DEVICE" mkpart primary ext3 150MB 100%
 fi
 
 echo "Waiting for disk sync..."
 sync
 
 echo "Formatting $DEVICE partitions..."
-mkfs.msdos -F 32 $DEVICE_BOOT
-mkfs.ext3 -q $DEVICE_ROOT
+mkfs.msdos -F 32 "$DEVICE_BOOT"
+mkfs.ext3 -q "$DEVICE_ROOT"
 
 echo "Waiting for disk sync..."
 sync
 
-mount $DEVICE_BOOT $BOOT_MNT
-mount $DEVICE_ROOT $ROOT_MNT
+mount "$DEVICE_BOOT" $BOOT_MNT
+mount "$DEVICE_ROOT" $ROOT_MNT
 
 echo "Unpacking EdgeOS release image"
-tar xf $TARBALL -C $DIR
+tar xf "$TARBALL" -C "$DIR"
 
 ####### Kernel
 echo "Verifying EdgeOS kernel"
-if [ `md5sum $DIR/vmlinux.tmp | awk -F ' ' '{print $1}'` != \
-     `cat $DIR/vmlinux.tmp.md5` ]; then
+if [ "$(md5sum "$DIR"/vmlinux.tmp | awk -F ' ' '{print $1}')" != \
+     "$(cat "$DIR"/vmlinux.tmp.md5)" ]; then
     echo "Kernel in image is corrupted! Check your image and start over."
     exit 1
 fi
 
 echo "Copying EdgeOS kernel to boot partition"
-cp $DIR/vmlinux.tmp $BOOT_MNT/vmlinux.64
-cp $DIR/vmlinux.tmp.md5 $BOOT_MNT/vmlinux.64.md5
+cp "$DIR"/vmlinux.tmp $BOOT_MNT/vmlinux.64
+cp "$DIR"/vmlinux.tmp.md5 $BOOT_MNT/vmlinux.64.md5
 
 ####### System
 echo "Verifying EdgeOS system image"
-if [ `md5sum $DIR/squashfs.tmp | awk -F ' ' '{print $1}'` != \
-     `cat $DIR/squashfs.tmp.md5` ]; then
+if [ "$(md5sum "$DIR"/squashfs.tmp | awk -F ' ' '{print $1}')" != \
+     "$(cat "$DIR"/squashfs.tmp.md5)" ]; then
     echo "System in image is corrupted! Check your image and start over."
     exit 1
 fi
 
 echo "Copying EdgeOS system image to root partition"
-mv $DIR/squashfs.tmp $ROOT_MNT/squashfs.img
-mv $DIR/squashfs.tmp.md5 $ROOT_MNT/squashfs.img.md5
+mv "$DIR"/squashfs.tmp $ROOT_MNT/squashfs.img
+mv "$DIR"/squashfs.tmp.md5 $ROOT_MNT/squashfs.img.md5
 
 echo "Copying version file to the root partition"
-mv $DIR/version.tmp $ROOT_MNT/version
+mv "$DIR"/version.tmp $ROOT_MNT/version
 
 # Writable data dir
 echo "Creating EdgeOS writable data directories"
@@ -129,10 +129,10 @@ mkdir $ROOT_MNT/www
 chown 33:0 $ROOT_MNT/www
 
 ####### Extract config
-if [ ! -z $CONFIG ] && [ -f $CONFIG ]
+if [ -n "$CONFIG" ] && [ -f "$CONFIG" ]
 then
     echo "Config archive $CONFIG was provided, extracting it to the root partition..."
-    tar xf $CONFIG -C $ROOT_MNT/w
+    tar xf "$CONFIG" -C $ROOT_MNT/w
 else
     echo "No config archive was provided, default settings will be used."
 fi

--- a/mkeosimg
+++ b/mkeosimg
@@ -1,15 +1,15 @@
 #!/bin/bash
 
 if [ "$EUID" -ne 0 ]
-then
     echo "Must run as root or with sudo."
+then
     exit 1
 fi
 
 TARBALL=${1}
 CONFIG=${2}
 DRIVESIZE=${3}
-DEVICE=`losetup -f`
+DEVICE=$(losetup -f)
 DEVICE_BOOT=${DEVICE}p1
 DEVICE_ROOT=${DEVICE}p2
 
@@ -31,7 +31,7 @@ mkdir -p $ROOT_MNT
 grep -qs "$BOOT_MNT" /proc/mounts && umount $BOOT_MNT
 grep -qs "$ROOT_MNT" /proc/mounts && umount $ROOT_MNT
 
-DIR=`mktemp -d`
+DIR=$(mktemp -d)
 
 function cleanup {
     if [ -d "$DIR" ]
@@ -50,7 +50,7 @@ function cleanup {
 trap cleanup EXIT
 
 ####### Check if config was supplied as a parameter and if it exists as a file
-if [ ! -z $CONFIG ] && [ -f $CONFIG ]
+if [ -n "$CONFIG" ] && [ -f "$CONFIG" ]
 then
     CONFIGURED_SUFFIX="-configured"
 else
@@ -58,58 +58,58 @@ else
 fi
 
 IMG=${TARBALL%.tar}${CONFIGURED_SUFFIX}.img
-rm -f $IMG.gz
+rm -f "$IMG.gz"
 
 # If no drive size was supplied as a parameter, default to 2 GB
-if [ -z $DRIVESIZE ]
+if [ -z "$DRIVESIZE" ]
 then
     DRIVESIZE=2
 fi
 
 echo "Creating $IMG with a size of $DRIVESIZE GB"
-let "SIZE = $DRIVESIZE * 1024"
-dd if=/dev/zero of=$IMG bs=1M count=0 seek=$SIZE
-losetup $DEVICE $IMG
-parted --script $DEVICE mktable msdos
-parted --script $DEVICE mkpart primary fat32 1 150MB
-parted --script $DEVICE mkpart primary ext3 150MB 100%
+(( SIZE = DRIVESIZE * 1024 ))
+dd if=/dev/zero of="$IMG" bs=1M count=0 seek="$SIZE"
+losetup "$DEVICE" "$IMG"
+parted --script "$DEVICE" mktable msdos
+parted --script "$DEVICE" mkpart primary fat32 1 150MB
+parted --script "$DEVICE" mkpart primary ext3 150MB 100%
 
 echo "Formatting $IMG"
-mkfs.msdos -F 32 $DEVICE_BOOT
-mkfs.ext3 -q $DEVICE_ROOT
+mkfs.msdos -F 32 "$DEVICE_BOOT"
+mkfs.ext3 -q "$DEVICE_ROOT"
 
-mount $DEVICE_BOOT $BOOT_MNT
-mount $DEVICE_ROOT $ROOT_MNT
+mount "$DEVICE_BOOT" $BOOT_MNT
+mount "$DEVICE_ROOT" $ROOT_MNT
 
 echo "Unpacking EdgeOS release image"
-tar xf $TARBALL -C $DIR
+tar xf "$TARBALL" -C "$DIR"
 
 ####### Kernel
 echo "Verifying EdgeOS kernel"
-if [ `md5sum $DIR/vmlinux.tmp | awk -F ' ' '{print $1}'` != \
-     `cat $DIR/vmlinux.tmp.md5` ]; then
+if [ "$(md5sum "$DIR"/vmlinux.tmp | awk -F ' ' '{print $1}')" != \
+     "$(cat "$DIR"/vmlinux.tmp.md5)" ]; then
     echo "Kernel in image is corrupted! Check your image and start over."
     exit 1
 fi
 
 echo "Copying EdgeOS kernel to boot partition"
-cp $DIR/vmlinux.tmp $BOOT_MNT/vmlinux.64
-cp $DIR/vmlinux.tmp.md5 $BOOT_MNT/vmlinux.64.md5
+cp "$DIR"/vmlinux.tmp $BOOT_MNT/vmlinux.64
+cp "$DIR"/vmlinux.tmp.md5 $BOOT_MNT/vmlinux.64.md5
 
 ####### System
 echo "Verifying EdgeOS system image"
-if [ `md5sum $DIR/squashfs.tmp | awk -F ' ' '{print $1}'` != \
-     `cat $DIR/squashfs.tmp.md5` ]; then
+if [ "$(md5sum "$DIR"/squashfs.tmp | awk -F ' ' '{print $1}')" != \
+     "$(cat "$DIR"/squashfs.tmp.md5)" ]; then
     echo "System in image is corrupted! Check your image and start over."
     exit 1
 fi
 
 echo "Copying EdgeOS system image to root partition"
-mv $DIR/squashfs.tmp $ROOT_MNT/squashfs.img
-mv $DIR/squashfs.tmp.md5 $ROOT_MNT/squashfs.img.md5
+mv "$DIR"/squashfs.tmp $ROOT_MNT/squashfs.img
+mv "$DIR"/squashfs.tmp.md5 $ROOT_MNT/squashfs.img.md5
 
 echo "Copying version file to the root partition"
-mv $DIR/version.tmp $ROOT_MNT/version
+mv "$DIR"/version.tmp $ROOT_MNT/version
 
 # Writable data dir
 echo "Creating EdgeOS writable data directories"
@@ -119,9 +119,9 @@ mkdir $ROOT_MNT/www
 chown 33:0 $ROOT_MNT/www
 
 ####### Extract config
-if [ ! -z $CONFIG ] && [ -f $CONFIG ]
+if [ -n "$CONFIG" ] && [ -f "$CONFIG" ]
 then
-    tar xf $CONFIG -C $ROOT_MNT/w
+    tar xf "$CONFIG" -C $ROOT_MNT/w
 fi
 
 # These need to happen before the losetup -d, or else the changes won't be
@@ -130,6 +130,6 @@ umount $ROOT_MNT
 umount $BOOT_MNT
 
 # Unhook img
-losetup -d $DEVICE
+losetup -d "$DEVICE"
 
 echo "Done."


### PR DESCRIPTION
`$ shellcheck mkeosdrive mkeosimg `

```
In mkeosdrive line 35:
umount ${DEVICE}? && echo "Unmounted all partitions on $DEVICE" || echo "no filesystem mounted from $DEVICE"
       ^-------^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean:
umount "${DEVICE}"? && echo "Unmounted all partitions on $DEVICE" || echo "no filesystem mounted from $DEVICE"

In mkeosdrive line 41:
DIR=`mktemp -d`
    ^---------^ SC2006 (style): Use $(...) notation instead of legacy backticks `...`.

Did you mean:
DIR=$(mktemp -d)

In mkeosdrive line 63:
dd if=/dev/zero of=$DEVICE bs=512 count=1 conv=notrunc
                   ^-----^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean:
dd if=/dev/zero of="$DEVICE" bs=512 count=1 conv=notrunc

In mkeosdrive line 68:
parted --script $DEVICE mktable msdos
                ^-----^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean:
parted --script "$DEVICE" mktable msdos

In mkeosdrive line 69:
parted --script $DEVICE mkpart primary fat32 1 150MB
                ^-----^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean:
parted --script "$DEVICE" mkpart primary fat32 1 150MB

In mkeosdrive line 72:
if [ ! -z $DRIVESIZE ]
     ^-- SC2236 (style): Use -n instead of ! -z.
          ^--------^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean:
if [ ! -z "$DRIVESIZE" ]

In mkeosdrive line 75:
    let "SIZE = $DRIVESIZE * 1024"
    ^---------------------------^ SC2219 (style): Instead of 'let expr', prefer (( expr )) .

In mkeosdrive line 76:
    parted --script $DEVICE mkpart primary ext3 150MB ${SIZE}MB
                    ^-----^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean:
    parted --script "$DEVICE" mkpart primary ext3 150MB ${SIZE}MB

In mkeosdrive line 78:
    parted --script $DEVICE mkpart primary ext3 150MB 100%
                    ^-----^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean:
    parted --script "$DEVICE" mkpart primary ext3 150MB 100%

In mkeosdrive line 85:
mkfs.msdos -F 32 $DEVICE_BOOT
                 ^----------^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean:
mkfs.msdos -F 32 "$DEVICE_BOOT"

In mkeosdrive line 86:
mkfs.ext3 -q $DEVICE_ROOT
             ^----------^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean:
mkfs.ext3 -q "$DEVICE_ROOT"

In mkeosdrive line 91:
mount $DEVICE_BOOT $BOOT_MNT
      ^----------^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean:
mount "$DEVICE_BOOT" $BOOT_MNT

In mkeosdrive line 92:
mount $DEVICE_ROOT $ROOT_MNT
      ^----------^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean:
mount "$DEVICE_ROOT" $ROOT_MNT

In mkeosdrive line 95:
tar xf $TARBALL -C $DIR
       ^------^ SC2086 (info): Double quote to prevent globbing and word splitting.
                   ^--^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean:
tar xf "$TARBALL" -C "$DIR"

In mkeosdrive line 99:
if [ `md5sum $DIR/vmlinux.tmp | awk -F ' ' '{print $1}'` != \
     ^-- SC2046 (warning): Quote this to prevent word splitting.
     ^-- SC2006 (style): Use $(...) notation instead of legacy backticks `...`.
             ^--^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean:
if [ $(md5sum "$DIR"/vmlinux.tmp | awk -F ' ' '{print $1}') != \

In mkeosdrive line 100:
     `cat $DIR/vmlinux.tmp.md5` ]; then
     ^------------------------^ SC2046 (warning): Quote this to prevent word splitting.
     ^------------------------^ SC2006 (style): Use $(...) notation instead of legacy backticks `...`.
          ^--^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean:
     $(cat "$DIR"/vmlinux.tmp.md5) ]; then

In mkeosdrive line 106:
cp $DIR/vmlinux.tmp $BOOT_MNT/vmlinux.64
   ^--^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean:
cp "$DIR"/vmlinux.tmp $BOOT_MNT/vmlinux.64

In mkeosdrive line 107:
cp $DIR/vmlinux.tmp.md5 $BOOT_MNT/vmlinux.64.md5
   ^--^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean:
cp "$DIR"/vmlinux.tmp.md5 $BOOT_MNT/vmlinux.64.md5

In mkeosdrive line 111:
if [ `md5sum $DIR/squashfs.tmp | awk -F ' ' '{print $1}'` != \
     ^-- SC2046 (warning): Quote this to prevent word splitting.
     ^-- SC2006 (style): Use $(...) notation instead of legacy backticks `...`.
             ^--^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean:
if [ $(md5sum "$DIR"/squashfs.tmp | awk -F ' ' '{print $1}') != \

In mkeosdrive line 112:
     `cat $DIR/squashfs.tmp.md5` ]; then
     ^-------------------------^ SC2046 (warning): Quote this to prevent word splitting.
     ^-------------------------^ SC2006 (style): Use $(...) notation instead of legacy backticks `...`.
          ^--^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean:
     $(cat "$DIR"/squashfs.tmp.md5) ]; then

In mkeosdrive line 118:
mv $DIR/squashfs.tmp $ROOT_MNT/squashfs.img
   ^--^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean:
mv "$DIR"/squashfs.tmp $ROOT_MNT/squashfs.img

In mkeosdrive line 119:
mv $DIR/squashfs.tmp.md5 $ROOT_MNT/squashfs.img.md5
   ^--^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean:
mv "$DIR"/squashfs.tmp.md5 $ROOT_MNT/squashfs.img.md5

In mkeosdrive line 122:
mv $DIR/version.tmp $ROOT_MNT/version
   ^--^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean:
mv "$DIR"/version.tmp $ROOT_MNT/version

In mkeosdrive line 132:
if [ ! -z $CONFIG ] && [ -f $CONFIG ]
     ^-- SC2236 (style): Use -n instead of ! -z.
          ^-----^ SC2086 (info): Double quote to prevent globbing and word splitting.
                            ^-----^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean:
if [ ! -z "$CONFIG" ] && [ -f "$CONFIG" ]

In mkeosdrive line 135:
    tar xf $CONFIG -C $ROOT_MNT/w
           ^-----^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean:
    tar xf "$CONFIG" -C $ROOT_MNT/w

In mkeosimg line 12:
DEVICE=`losetup -f`
       ^----------^ SC2006 (style): Use $(...) notation instead of legacy backticks `...`.

Did you mean:
DEVICE=$(losetup -f)

In mkeosimg line 34:
DIR=`mktemp -d`
    ^---------^ SC2006 (style): Use $(...) notation instead of legacy backticks `...`.

Did you mean:
DIR=$(mktemp -d)

In mkeosimg line 53:
if [ ! -z $CONFIG ] && [ -f $CONFIG ]
     ^-- SC2236 (style): Use -n instead of ! -z.
          ^-----^ SC2086 (info): Double quote to prevent globbing and word splitting.
                            ^-----^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean:
if [ ! -z "$CONFIG" ] && [ -f "$CONFIG" ]

In mkeosimg line 61:
rm -f $IMG.gz
      ^--^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean:
rm -f "$IMG".gz

In mkeosimg line 64:
if [ -z $DRIVESIZE ]
        ^--------^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean:
if [ -z "$DRIVESIZE" ]

In mkeosimg line 70:
let "SIZE = $DRIVESIZE * 1024"
^---------------------------^ SC2219 (style): Instead of 'let expr', prefer (( expr )) .

In mkeosimg line 71:
dd if=/dev/zero of=$IMG bs=1M count=0 seek=$SIZE
                   ^--^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean:
dd if=/dev/zero of="$IMG" bs=1M count=0 seek=$SIZE

In mkeosimg line 72:
losetup $DEVICE $IMG
        ^-----^ SC2086 (info): Double quote to prevent globbing and word splitting.
                ^--^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean:
losetup "$DEVICE" "$IMG"

In mkeosimg line 73:
parted --script $DEVICE mktable msdos
                ^-----^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean:
parted --script "$DEVICE" mktable msdos

In mkeosimg line 74:
parted --script $DEVICE mkpart primary fat32 1 150MB
                ^-----^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean:
parted --script "$DEVICE" mkpart primary fat32 1 150MB

In mkeosimg line 75:
parted --script $DEVICE mkpart primary ext3 150MB 100%
                ^-----^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean:
parted --script "$DEVICE" mkpart primary ext3 150MB 100%

In mkeosimg line 78:
mkfs.msdos -F 32 $DEVICE_BOOT
                 ^----------^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean:
mkfs.msdos -F 32 "$DEVICE_BOOT"

In mkeosimg line 79:
mkfs.ext3 -q $DEVICE_ROOT
             ^----------^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean:
mkfs.ext3 -q "$DEVICE_ROOT"

In mkeosimg line 81:
mount $DEVICE_BOOT $BOOT_MNT
      ^----------^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean:
mount "$DEVICE_BOOT" $BOOT_MNT

In mkeosimg line 82:
mount $DEVICE_ROOT $ROOT_MNT
      ^----------^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean:
mount "$DEVICE_ROOT" $ROOT_MNT

In mkeosimg line 85:
tar xf $TARBALL -C $DIR
       ^------^ SC2086 (info): Double quote to prevent globbing and word splitting.
                   ^--^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean:
tar xf "$TARBALL" -C "$DIR"

In mkeosimg line 89:
if [ `md5sum $DIR/vmlinux.tmp | awk -F ' ' '{print $1}'` != \
     ^-- SC2046 (warning): Quote this to prevent word splitting.
     ^-- SC2006 (style): Use $(...) notation instead of legacy backticks `...`.
             ^--^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean:
if [ $(md5sum "$DIR"/vmlinux.tmp | awk -F ' ' '{print $1}') != \

In mkeosimg line 90:
     `cat $DIR/vmlinux.tmp.md5` ]; then
     ^------------------------^ SC2046 (warning): Quote this to prevent word splitting.
     ^------------------------^ SC2006 (style): Use $(...) notation instead of legacy backticks `...`.
          ^--^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean:
     $(cat "$DIR"/vmlinux.tmp.md5) ]; then

In mkeosimg line 96:
cp $DIR/vmlinux.tmp $BOOT_MNT/vmlinux.64
   ^--^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean:
cp "$DIR"/vmlinux.tmp $BOOT_MNT/vmlinux.64

In mkeosimg line 97:
cp $DIR/vmlinux.tmp.md5 $BOOT_MNT/vmlinux.64.md5
   ^--^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean:
cp "$DIR"/vmlinux.tmp.md5 $BOOT_MNT/vmlinux.64.md5

In mkeosimg line 101:
if [ `md5sum $DIR/squashfs.tmp | awk -F ' ' '{print $1}'` != \
     ^-- SC2046 (warning): Quote this to prevent word splitting.
     ^-- SC2006 (style): Use $(...) notation instead of legacy backticks `...`.
             ^--^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean:
if [ $(md5sum "$DIR"/squashfs.tmp | awk -F ' ' '{print $1}') != \

In mkeosimg line 102:
     `cat $DIR/squashfs.tmp.md5` ]; then
     ^-------------------------^ SC2046 (warning): Quote this to prevent word splitting.
     ^-------------------------^ SC2006 (style): Use $(...) notation instead of legacy backticks `...`.
          ^--^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean:
     $(cat "$DIR"/squashfs.tmp.md5) ]; then

In mkeosimg line 108:
mv $DIR/squashfs.tmp $ROOT_MNT/squashfs.img
   ^--^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean:
mv "$DIR"/squashfs.tmp $ROOT_MNT/squashfs.img

In mkeosimg line 109:
mv $DIR/squashfs.tmp.md5 $ROOT_MNT/squashfs.img.md5
   ^--^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean:
mv "$DIR"/squashfs.tmp.md5 $ROOT_MNT/squashfs.img.md5

In mkeosimg line 112:
mv $DIR/version.tmp $ROOT_MNT/version
   ^--^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean:
mv "$DIR"/version.tmp $ROOT_MNT/version

In mkeosimg line 122:
if [ ! -z $CONFIG ] && [ -f $CONFIG ]
     ^-- SC2236 (style): Use -n instead of ! -z.
          ^-----^ SC2086 (info): Double quote to prevent globbing and word splitting.
                            ^-----^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean:
if [ ! -z "$CONFIG" ] && [ -f "$CONFIG" ]

In mkeosimg line 124:
    tar xf $CONFIG -C $ROOT_MNT/w
           ^-----^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean:
    tar xf "$CONFIG" -C $ROOT_MNT/w

In mkeosimg line 133:
losetup -d $DEVICE
           ^-----^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean:
losetup -d "$DEVICE"

For more information:
  https://www.shellcheck.net/wiki/SC2046 -- Quote this to prevent word splitt...
  https://www.shellcheck.net/wiki/SC2086 -- Double quote to prevent globbing ...
  https://www.shellcheck.net/wiki/SC2006 -- Use $(...) notation instead of le...
```